### PR TITLE
Add dashboard pages for admin and user

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Header: React.FC = () => {
+  return (
+    <header>
+      <nav>
+        <ul>
+          <li>
+            <Link to="/">Home</Link>
+          </li>
+          <li>
+            <Link to="/services">Services</Link>
+          </li>
+          <li>
+            <Link to="/dashboard">User Dashboard</Link>
+          </li>
+          <li>
+            <Link to="/admin">Admin Dashboard</Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/src/features/admin/AdminDashboard.tsx
+++ b/frontend/src/features/admin/AdminDashboard.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { fetchProjects, fetchServices } from '../../lib/apiClient';
+
+const AdminDashboard = () => {
+  const [projects, setProjects] = useState([]);
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    const getProjects = async () => {
+      const projectsData = await fetchProjects();
+      setProjects(projectsData);
+    };
+
+    const getServices = async () => {
+      const servicesData = await fetchServices();
+      setServices(servicesData);
+    };
+
+    getProjects();
+    getServices();
+  }, []);
+
+  return (
+    <div>
+      <h1>Admin Dashboard</h1>
+      <section>
+        <h2>Projects</h2>
+        <ul>
+          {projects.map((project) => (
+            <li key={project.id}>{project.name}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2>Services</h2>
+        <ul>
+          {services.map((service) => (
+            <li key={service.id}>{service.name}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/frontend/src/features/dashboard/Dashboard.tsx
+++ b/frontend/src/features/dashboard/Dashboard.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { fetchUserProjects, fetchUserServices } from '../../lib/apiClient';
+
+const Dashboard = () => {
+  const [projects, setProjects] = useState([]);
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const userProjects = await fetchUserProjects();
+      const userServices = await fetchUserServices();
+      setProjects(userProjects);
+      setServices(userServices);
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <div>
+      <h1>User Dashboard</h1>
+      <section>
+        <h2>User Projects</h2>
+        <ul>
+          {projects.map((project) => (
+            <li key={project.id}>{project.name}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2>User Services</h2>
+        <ul>
+          {services.map((service) => (
+            <li key={service.id}>{service.name}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/features/services/ServicesPage.tsx
+++ b/frontend/src/features/services/ServicesPage.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { fetchServices } from '../../hooks/useServices';
+
+const ServicesPage = () => {
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    const getServices = async () => {
+      const servicesList = await fetchServices();
+      setServices(servicesList);
+    };
+
+    getServices();
+  }, []);
+
+  return (
+    <div>
+      <h1>Public Services</h1>
+      <ul>
+        {services.map((service) => (
+          <li key={service.id}>{service.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ServicesPage;

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { AuthContext } from '../providers/AuthProvider';
+
+const useAuth = () => {
+  const { user } = useContext(AuthContext);
+
+  const isAdmin = () => {
+    return user?.role === 'admin';
+  };
+
+  return {
+    user,
+    isAdmin,
+  };
+};
+
+export default useAuth;

--- a/frontend/src/hooks/useServices.ts
+++ b/frontend/src/hooks/useServices.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+import { fetchServices } from '../lib/apiClient';
+
+const useServices = () => {
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    const getServices = async () => {
+      const servicesList = await fetchServices();
+      setServices(servicesList);
+    };
+
+    getServices();
+  }, []);
+
+  return services;
+};
+
+export default useServices;

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export const fetchProjects = async () => {
+  try {
+    const response = await apiClient.get('/projects');
+    return response.data.projects;
+  } catch (error) {
+    console.error('Error fetching projects:', error);
+    throw error;
+  }
+};
+
+export const fetchServices = async () => {
+  try {
+    const response = await apiClient.get('/services');
+    return response.data.services;
+  } catch (error) {
+    console.error('Error fetching services:', error);
+    throw error;
+  }
+};

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import AdminDashboard from '../features/admin/AdminDashboard';
+
+const AdminPage = () => {
+  return (
+    <div>
+      <AdminDashboard />
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { fetchUserProjects, fetchUserServices } from '../lib/apiClient';
+
+const Dashboard = () => {
+  const [projects, setProjects] = useState([]);
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const userProjects = await fetchUserProjects();
+      const userServices = await fetchUserServices();
+      setProjects(userProjects);
+      setServices(userServices);
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <div>
+      <h1>User Dashboard</h1>
+      <section>
+        <h2>User Projects</h2>
+        <ul>
+          {projects.map((project) => (
+            <li key={project.id}>{project.name}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2>User Services</h2>
+        <ul>
+          {services.map((service) => (
+            <li key={service.id}>{service.name}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/services.tsx
+++ b/frontend/src/pages/services.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { fetchServices } from '../hooks/useServices';
+
+const ServicesPage = () => {
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    const getServices = async () => {
+      const servicesList = await fetchServices();
+      setServices(servicesList);
+    };
+
+    getServices();
+  }, []);
+
+  return (
+    <div>
+      <h1>Services</h1>
+      <ul>
+        {services.map((service) => (
+          <li key={service.id}>{service.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ServicesPage;

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useState, useEffect } from 'react';
+import { fetchUser } from '../lib/apiClient';
+
+export const AuthContext = createContext(null);
+
+const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const userData = await fetchUser();
+      setUser(userData);
+      setLoading(false);
+    };
+
+    fetchData();
+  }, []);
+
+  const isAdmin = () => {
+    return user?.role === 'admin';
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, isAdmin, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthProvider;

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import HomePage from '../pages/index';
+import LoginPage from '../pages/login';
+import RegisterPage from '../pages/register';
+import ServicesPage from '../pages/services';
+import DashboardPage from '../pages/dashboard';
+import AdminPage from '../pages/admin';
+
+const AppRouter = () => {
+  return (
+    <Router>
+      <Switch>
+        <Route exact path="/" component={HomePage} />
+        <Route path="/login" component={LoginPage} />
+        <Route path="/register" component={RegisterPage} />
+        <Route path="/services" component={ServicesPage} />
+        <Route path="/dashboard" component={DashboardPage} />
+        <Route path="/admin" component={AdminPage} />
+      </Switch>
+    </Router>
+  );
+};
+
+export default AppRouter;

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,78 @@
+/* Global styles for the Admin Dashboard, User Dashboard, and Services pages */
+
+/* Admin Dashboard styles */
+.admin-dashboard {
+  background-color: #f8f9fa;
+  padding: 20px;
+}
+
+.admin-dashboard h1 {
+  font-size: 2rem;
+  color: #343a40;
+}
+
+.admin-dashboard section {
+  margin-bottom: 20px;
+}
+
+.admin-dashboard ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+.admin-dashboard li {
+  background-color: #ffffff;
+  border: 1px solid #dee2e6;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+/* User Dashboard styles */
+.user-dashboard {
+  background-color: #f8f9fa;
+  padding: 20px;
+}
+
+.user-dashboard h1 {
+  font-size: 2rem;
+  color: #343a40;
+}
+
+.user-dashboard section {
+  margin-bottom: 20px;
+}
+
+.user-dashboard ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+.user-dashboard li {
+  background-color: #ffffff;
+  border: 1px solid #dee2e6;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+/* Services Page styles */
+.services-page {
+  background-color: #f8f9fa;
+  padding: 20px;
+}
+
+.services-page h1 {
+  font-size: 2rem;
+  color: #343a40;
+}
+
+.services-page ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+.services-page li {
+  background-color: #ffffff;
+  border: 1px solid #dee2e6;
+  padding: 10px;
+  margin-bottom: 10px;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,35 @@
+export interface Project {
+  id: string;
+  name: string;
+  description: string;
+  clientId: string;
+  startDate: string;
+  endDate: string;
+  status: string;
+  budget: number;
+  projectManager: string;
+  teamMembers: string[];
+}
+
+export interface Service {
+  id: string;
+  name: string;
+  description: string;
+  price: number;
+  duration: string;
+  category: string;
+}
+
+export interface User {
+  id: string;
+  username: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string;
+  address: string;
+  dateOfBirth: string;
+  profilePicture: string;
+  role: string;
+  status: string;
+}


### PR DESCRIPTION
Add new features and pages for the Admin Dashboard, User Dashboard, and Services.

* **Header Component**
  - Add navigation links for "Admin Dashboard" and "User Dashboard".

* **Admin Dashboard**
  - Add sections to display lists of projects and services.

* **User Dashboard**
  - Add sections to display lists of user projects and services.

* **Services Page**
  - Add section to display a list of public services.

* **Hooks**
  - Add `useAuth` hook to check if the user is an admin.
  - Add `useServices` hook to fetch a list of services.

* **API Client**
  - Add functions to fetch lists of projects and services.

* **Pages**
  - Create new pages for "Admin Dashboard", "User Dashboard", and "Services".

* **Auth Provider**
  - Add context provider for the admin role.

* **Router**
  - Add routes for "Admin Dashboard", "User Dashboard", and "Services" pages.

* **Styles**
  - Add global styles for "Admin Dashboard", "User Dashboard", and "Services" pages.

* **Types**
  - Add types for projects, services, and users.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/web-design-agency/pull/2?shareId=fbb01257-0271-4c32-af7f-ff153c096a82).